### PR TITLE
keystore: Place keystore at the last 4k boundary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
 
 script:
     # Build BPAK library and tools
-    - git clone https://github.com/jonasblixt/bpak --depth 1 --branch v0.4.0
+    - git clone https://github.com/jonasblixt/bpak --depth 1 --branch v0.5.11
     - pushd bpak
     - autoreconf -fi
     - ./configure
@@ -32,7 +32,7 @@ script:
     - popd
 
     # Build punchboot library and tools
-    - git clone https://github.com/jonasblixt/punchboot-tools --depth 1 --branch v0.2.3
+    - git clone https://github.com/jonasblixt/punchboot-tools --depth 1 --branch v0.2.5
     - pushd punchboot-tools
     - autoreconf -fi
     - ./configure

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ all: $(BUILD_DIR)/$(TARGET).bin $(plat-y)
 
 $(BUILD_DIR)/keystore.o:
 	@echo GEN $(BUILD_DIR)/keystore.c
-	$(Q)$(BPAK) generate keystore --name pb $(CONFIG_KEYSTORE) > $(BUILD_DIR)/keystore.c
+	$(Q)$(BPAK) generate keystore --name pb $(CONFIG_KEYSTORE) --decorate > $(BUILD_DIR)/keystore.c
 	$(Q)$(CC) -c $(cflags-y) $(BUILD_DIR)/keystore.c -o $(BUILD_DIR)/keystore.o
 
 $(BUILD_DIR)/$(TARGET).bin: $(BUILD_DIR)/$(TARGET)

--- a/link.lds
+++ b/link.lds
@@ -42,6 +42,9 @@ SECTIONS
         *(.rodata .rodata.*)
         . = ALIGN(4096);
         _edata = .;
+        *(.keystore_header)
+        *(.keystore_key)
+        . = ALIGN(4096);
         PROVIDE (_ro_data_region_end = .);
     } > pbram
 


### PR DESCRIPTION
This changes the linker script so that the keystore header is placed on
the last 4k boundary relative the end of the output binary. Key structs
are placed directly after the keystore header.

This is done to make key material extraction possible.