### PR TITLE
wdog: Add configuration for if watchdog should be disabled in debug and/or wait mode

### DIFF
--- a/src/drivers/wdog/Kconfig
+++ b/src/drivers/wdog/Kconfig
@@ -5,4 +5,14 @@ config DRIVERS_IMX_WDOG
     default n
     depends on SOC_FAMILY_IMX
 
+config DRIVERS_IMX_WDOG_DEBUG
+    bool "Disable watchdog in debug"
+    default n
+    depends on DRIVERS_IMX_WDOG
+
+config DRIVERS_IMX_WDOG_WAIT
+    bool "Disable watchdog in wait mode"
+    default n
+    depends on DRIVERS_IMX_WDOG
+
 endmenu

--- a/src/drivers/wdog/imx_wdog.c
+++ b/src/drivers/wdog/imx_wdog.c
@@ -24,10 +24,19 @@ int imx_wdog_init(uintptr_t base_, unsigned int delay_s)
     base = base_;
 
     /* Timeout value = 9 * 0.5 + 0.5 = 5 s */
-    mmio_write_16(base + WDOG_WCR, ((delay_s * 2) << 8) | (1 << 2) |
-                                    (1 << 3) |
-                                    (1 << 4) |
-                                    (1 << 5));
+    uint16_t regval = ((delay_s * 2) << 8) |
+                            (1 << 2) |
+                            (1 << 3) |
+                            (1 << 4) |
+                            (1 << 5);
+
+#ifdef CONFIG_DRIVERS_IMX_WDOG_DEBUG
+    regval |= (1 << 1);
+#endif
+#ifdef CONFIG_DRIVERS_IMX_WDOG_WAIT
+    regval |= (1 << 7);
+#endif
+    mmio_write_16(base + WDOG_WCR, regval);
 
     mmio_write_16(base + WDOG_WMCR, 0);
 


### PR DESCRIPTION
Allowing the watchdog to be stopped in debug mode is required to make gdb debugging feasible, and as the watchdog might not be changed by the next boot step before attaching gdb, it helps if bootloader can set it in that mode already.