### PR TITLE
drivers/usb/usbd: Add Microsoft OS Descriptors

### DIFF
--- a/include/drivers/usb/usbd.h
+++ b/include/drivers/usb/usbd.h
@@ -140,6 +140,27 @@ struct usb_endpoint_descriptor {
     uint8_t bInterval; // Interval for polling endpoint for data transfers
 } __attribute__((packed));
 
+struct usb_msft_os_descriptor {
+    uint8_t bLength;
+    uint8_t bDescriptorType;
+    uint8_t signature[14];
+    uint8_t bVendorCode;
+    uint8_t bPad;
+} __attribute__((packed));
+
+struct usb_msft_comp_id_feature {
+    uint32_t length;
+    uint8_t bcdVersion[2];
+    uint16_t wCompIDidx;
+    uint8_t bNumSel;
+    uint8_t rz1[7];
+    uint8_t bIfaceNo;
+    uint8_t rz2;
+    uint8_t compatibleId[8];
+    uint8_t subCompatibleId[8];
+    uint8_t rz3[6];
+} __attribute__((packed));
+
 struct usbd_descriptors {
     const struct usb_language_descriptor language;
     const struct usb_qualifier_descriptor qualifier;


### PR DESCRIPTION
When a new USB device enumerates on Windows the system will ask for string descriptor 0xEE, Which is Windows specific, if the string descriptor contains 'MSFT100' it will issue a vendor specific request for a 'Microsoft Compatible ID Feature Descriptor'.

With these two in place Windows will automatically bind the device to WinUSB and in turn we can use libusb directly.

Historically this was handled by the windows binary installer that bundeled libwdi.

It's explained in greater detail here:
    https://github.com/pbatard/libwdi/wiki/WCID-Devices