### PR TITLE
drivers: crypto: caam: Reset R/S buffers

### DIFF
--- a/src/drivers/crypto/caam/imx_caam.c
+++ b/src/drivers/crypto/caam/imx_caam.c
@@ -248,6 +248,8 @@ static int caam_ecda_verify(const uint8_t *der_signature,
         return rc;
 
     memset(caam.ecdsa_tmp_buf, 0, sizeof(caam.ecdsa_tmp_buf));
+    memset(caam.ecdsa_r, 0, CAAM_SIG_MAX_LENGTH / 2);
+    memset(caam.ecdsa_s, 0, CAAM_SIG_MAX_LENGTH / 2);
 
     switch (key_kind) {
     case DSA_EC_SECP256r1:


### PR DESCRIPTION
In commit 'c61b0743ece0' a fix was introduces to deal with varying length of the R and S integers when they are ASN1 encoded. The CAAM expect's it's input buffers to have leading zeroes.

This fix however did not clear the R/S buffers which leads to uninitialized data at the start of the buffers when the ASN1 data is shorter than what the CAAM expects.